### PR TITLE
add: manual checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ const App = () => {
       <button key="decrement" onClick={() => setCount(presentCount - 1, true)}>
         WithCheckpoint-
       </button>
-      <button key="increment" onClick={() => setCount(presentCount + 1, true)}>
+      <button key="increment" onClick={() => setCount(presentCount + 1)}>
         NoCheckpoint+
       </button>
-      <button key="decrement" onClick={() => setCount(presentCount - 1, true)}>
+      <button key="decrement" onClick={() => setCount(presentCount - 1)}>
         NoCheckpoint-
       </button>
       <button key="undo" onClick={undoCount} disabled={!canUndo}>

--- a/README.md
+++ b/README.md
@@ -63,6 +63,58 @@ const App = () => {
 };
 ```
 
+## Manual Checkpoints
+
+Manual checkpoints are helpful also when you want manual control over checkpoints. For example it is more helpful when you want to handle input type html tag where value needs to be handled alongside the undo and redo functionality should be handled over some conditions.
+
+```js
+import React from 'react';
+import ReactDOM from 'react-dom';
+import useUndo from 'use-undo';
+
+const App = () => {
+  const [
+    countState,
+    {
+      set: setCount,
+      reset: resetCount,
+      undo: undoCount,
+      redo: redoCount,
+      canUndo,
+      canRedo,
+    },
+  ] = useUndo(0, { useCheckpoints: true });
+  const { present: presentCount } = countState;
+
+  return (
+    <div>
+      <p>You clicked {presentCount} times</p>
+      <button key="increment" onClick={() => setCount(presentCount + 1, true)}>
+        WithCheckpoint+
+      </button>
+      <button key="decrement" onClick={() => setCount(presentCount - 1, true)}>
+        WithCheckpoint-
+      </button>
+      <button key="increment" onClick={() => setCount(presentCount + 1, true)}>
+        NoCheckpoint+
+      </button>
+      <button key="decrement" onClick={() => setCount(presentCount - 1, true)}>
+        NoCheckpoint-
+      </button>
+      <button key="undo" onClick={undoCount} disabled={!canUndo}>
+        undo
+      </button>
+      <button key="redo" onClick={redoCount} disabled={!canRedo}>
+        redo
+      </button>
+      <button key="reset" onClick={() => resetCount(0)}>
+        reset to 0
+      </button>
+    </div>
+  );
+};
+```
+
 ## API
 
 ### useUndo

--- a/__test__/checkpoint.spec.tsx
+++ b/__test__/checkpoint.spec.tsx
@@ -1,0 +1,342 @@
+import React from 'react';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+
+import useUndo from '../index';
+
+const UndoComponent = ({
+  disabled,
+  manualCheckpoints,
+}: {
+  disabled: boolean;
+  manualCheckpoints: boolean;
+}) => {
+  const [
+    countState,
+    {
+      set: setCount,
+      reset: resetCount,
+      undo: undoCount,
+      redo: redoCount,
+      canUndo,
+      canRedo,
+    },
+  ] = useUndo(0, { useCheckpoints: manualCheckpoints });
+  const { present: presentCount } = countState;
+  const doubleRedoCount = () => {
+    redoCount();
+    redoCount();
+  };
+  const doubleUndoCount = () => {
+    undoCount();
+    undoCount();
+  };
+
+  return (
+    <div>
+      <p data-testid="count">count: {presentCount}</p>
+      <button
+        key="withcheck-increment"
+        data-testid="withcheck-increment"
+        onClick={() => setCount(presentCount + 1, true)}
+      >
+        Checkpoint+
+      </button>
+      <button
+        key="withcheck-decrement"
+        data-testid="withcheck-decrement"
+        onClick={() => setCount(presentCount - 1, true)}
+      >
+        Checkpoint-
+      </button>
+      <button
+        key="unchange"
+        data-testid="unchange"
+        onClick={() => setCount(presentCount)}
+      >
+        unchange
+      </button>
+      <button
+        key="nocheckincrement"
+        data-testid="nocheckincrement"
+        onClick={() => setCount(presentCount + 1)}
+      >
+        NoCheckpoint+
+      </button>
+      <button
+        key="nocheckdecrement"
+        data-testid="nocheckdecrement"
+        onClick={() => setCount(presentCount - 1)}
+      >
+        NoCheckpoint-
+      </button>
+      <button
+        key="undo"
+        data-testid="undo"
+        onClick={undoCount}
+        disabled={disabled && !canUndo}
+      >
+        undo
+      </button>
+      <button
+        key="redo"
+        data-testid="redo"
+        onClick={redoCount}
+        disabled={disabled && !canRedo}
+      >
+        redo
+      </button>
+      <button
+        key="double undo"
+        data-testid="double undo"
+        onClick={doubleUndoCount}
+        disabled={disabled && !canUndo}
+      >
+        double undo
+      </button>
+      <button
+        key="double redo"
+        data-testid="double redo"
+        onClick={doubleRedoCount}
+        disabled={disabled && !canRedo}
+      >
+        double redo
+      </button>
+      <button key="reset" data-testid="reset" onClick={() => resetCount(0)}>
+        reset to 0
+      </button>
+    </div>
+  );
+};
+
+type SetupArg = {
+  defaultDisabled: boolean;
+  manualCheckpoints: boolean;
+};
+
+const setup = (opts: Partial<SetupArg> = {}) => {
+  const { defaultDisabled, manualCheckpoints }: Partial<SetupArg> = {
+    defaultDisabled: true,
+    manualCheckpoints: false,
+    ...opts,
+  };
+  const { getByTestId } = render(
+    <UndoComponent
+      disabled={defaultDisabled}
+      manualCheckpoints={manualCheckpoints}
+    />
+  );
+
+  const count = getByTestId('count');
+  const unchangeButton = getByTestId('unchange') as HTMLButtonElement;
+
+  const withcheckincrementButton = getByTestId(
+    'withcheck-increment'
+  ) as HTMLButtonElement;
+  const withcheckdecrementButton = getByTestId(
+    'withcheck-decrement'
+  ) as HTMLButtonElement;
+  const nocheckincrementButton = getByTestId(
+    'nocheckincrement'
+  ) as HTMLButtonElement;
+  const nocheckdecrementButton = getByTestId(
+    'nocheckdecrement'
+  ) as HTMLButtonElement;
+  const undoButton = getByTestId('undo') as HTMLButtonElement;
+  const redoButton = getByTestId('redo') as HTMLButtonElement;
+  const doubleUndoButton = getByTestId('double undo') as HTMLButtonElement;
+  const doubleRedoButton = getByTestId('double redo') as HTMLButtonElement;
+  const resetButton = getByTestId('reset') as HTMLButtonElement;
+
+  return {
+    count,
+    unchangeButton,
+    nocheckincrementButton,
+    nocheckdecrementButton,
+    withcheckincrementButton,
+    withcheckdecrementButton,
+    undoButton,
+    redoButton,
+    doubleUndoButton,
+    doubleRedoButton,
+    resetButton,
+  };
+};
+
+describe('use-undo', () => {
+  afterEach(cleanup);
+
+  it('should exist', () => {
+    expect(useUndo).toBeDefined();
+  });
+
+  it('should work with checkpoints', () => {
+    const {
+      count,
+      unchangeButton,
+      withcheckincrementButton,
+      withcheckdecrementButton,
+      undoButton,
+      redoButton,
+      resetButton,
+    } = setup({ manualCheckpoints: true });
+
+    // with checkpoints test cases
+    expect(count.textContent).toBe('count: 0');
+    expect(undoButton.disabled).toBe(true);
+    expect(redoButton.disabled).toBe(true);
+
+    fireEvent.click(withcheckincrementButton);
+    fireEvent.click(withcheckincrementButton);
+    fireEvent.click(withcheckincrementButton);
+
+    expect(count.textContent).toBe('count: 3');
+    expect(undoButton.disabled).toBe(false);
+    expect(redoButton.disabled).toBe(true);
+
+    fireEvent.click(unchangeButton);
+
+    expect(count.textContent).toBe('count: 3');
+    expect(undoButton.disabled).toBe(false);
+    expect(redoButton.disabled).toBe(true);
+
+    fireEvent.click(withcheckdecrementButton);
+    fireEvent.click(withcheckdecrementButton);
+    fireEvent.click(withcheckdecrementButton);
+
+    expect(count.textContent).toBe('count: 0');
+    expect(undoButton.disabled).toBe(false);
+    expect(redoButton.disabled).toBe(true);
+
+    fireEvent.click(undoButton);
+    fireEvent.click(undoButton);
+    fireEvent.click(undoButton);
+
+    expect(count.textContent).toBe('count: 3');
+    expect(undoButton.disabled).toBe(false);
+    expect(redoButton.disabled).toBe(false);
+
+    fireEvent.click(redoButton);
+    fireEvent.click(redoButton);
+    fireEvent.click(redoButton);
+
+    expect(count.textContent).toBe('count: 0');
+    expect(undoButton.disabled).toBe(false);
+    expect(redoButton.disabled).toBe(true);
+
+    fireEvent.click(undoButton);
+    fireEvent.click(undoButton);
+    fireEvent.click(undoButton);
+    fireEvent.click(undoButton);
+    fireEvent.click(undoButton);
+    fireEvent.click(undoButton);
+
+    expect(count.textContent).toBe('count: 0');
+    expect(undoButton.disabled).toBe(true);
+    expect(redoButton.disabled).toBe(false);
+
+    fireEvent.click(withcheckincrementButton);
+    fireEvent.click(withcheckincrementButton);
+    fireEvent.click(resetButton);
+
+    expect(count.textContent).toBe('count: 0');
+    expect(undoButton.disabled).toBe(true);
+    expect(redoButton.disabled).toBe(true);
+  });
+
+  it('should work without checkpoints', () => {
+    const {
+      count,
+      unchangeButton,
+      nocheckincrementButton,
+      nocheckdecrementButton,
+      undoButton,
+      redoButton,
+      resetButton,
+    } = setup({ manualCheckpoints: true });
+
+    // without checkpoints test cases
+    expect(count.textContent).toBe('count: 0');
+    expect(undoButton.disabled).toBe(true);
+    expect(redoButton.disabled).toBe(true);
+
+    fireEvent.click(nocheckincrementButton);
+    fireEvent.click(nocheckincrementButton);
+    fireEvent.click(nocheckincrementButton);
+
+    expect(count.textContent).toBe('count: 3');
+    expect(undoButton.disabled).toBe(true);
+    expect(redoButton.disabled).toBe(true);
+
+    fireEvent.click(unchangeButton);
+
+    expect(count.textContent).toBe('count: 3');
+    expect(undoButton.disabled).toBe(true);
+    expect(redoButton.disabled).toBe(true);
+
+    fireEvent.click(nocheckdecrementButton);
+    fireEvent.click(nocheckdecrementButton);
+    fireEvent.click(nocheckdecrementButton);
+
+    expect(count.textContent).toBe('count: 0');
+    expect(undoButton.disabled).toBe(true);
+    expect(redoButton.disabled).toBe(true);
+
+    fireEvent.click(nocheckincrementButton);
+    fireEvent.click(nocheckincrementButton);
+    fireEvent.click(resetButton);
+
+    expect(count.textContent).toBe('count: 0');
+    expect(undoButton.disabled).toBe(true);
+    expect(redoButton.disabled).toBe(true);
+  });
+
+  it('present count should not be changed when canUndo or canRedo is false', () => {
+    const { count, undoButton, redoButton } = setup({ defaultDisabled: false });
+
+    expect(count.textContent).toBe('count: 0');
+    expect(undoButton.disabled).toBe(false);
+    expect(redoButton.disabled).toBe(false);
+
+    fireEvent.click(undoButton);
+
+    expect(count.textContent).toBe('count: 0');
+
+    fireEvent.click(redoButton);
+
+    expect(count.textContent).toBe('count: 0');
+  });
+
+  describe('when it can undo once', () => {
+    describe('when calling undo multiple times in succession', () => {
+      it('should return to the initial state', () => {
+        const { count, doubleUndoButton, withcheckincrementButton } = setup();
+
+        fireEvent.click(withcheckincrementButton);
+
+        fireEvent.click(doubleUndoButton);
+
+        expect(count.textContent).toBe('count: 0');
+      });
+    });
+  });
+
+  describe('when it can redo once', () => {
+    describe('when calling redo multiple times in succession', () => {
+      it('should return to the last state', () => {
+        const {
+          count,
+          undoButton,
+          doubleRedoButton,
+          withcheckincrementButton,
+        } = setup();
+
+        fireEvent.click(withcheckincrementButton);
+        fireEvent.click(undoButton);
+
+        fireEvent.click(doubleRedoButton);
+
+        expect(count.textContent).toBe('count: 1');
+      });
+    });
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -38,7 +38,10 @@ type Options = {
   useCheckpoints?: boolean;
 };
 
-const useUndo = <T>(initialPresent: T, opts = {}): [State<T>, Actions<T>] => {
+const useUndo = <T>(
+  initialPresent: T,
+  opts: Options = {}
+): [State<T>, Actions<T>] => {
   const { useCheckpoints }: Options = {
     useCheckpoints: false,
     ...opts,
@@ -88,7 +91,7 @@ const useUndo = <T>(initialPresent: T, opts = {}): [State<T>, Actions<T>] => {
         }
 
         return {
-          past: isNewCheckpoint == false ? past : [...past, present],
+          past: isNewCheckpoint === false ? past : [...past, present],
           present: newPresent,
           future: [],
         };


### PR DESCRIPTION
Right now i am using this package with list of form. the problem is if we change input value, then also. history is getting recorded. i have a delete button. so I need a manual control over recording history. other packages have added manual checkpoint option. but those are required to use reducer. but in this package it is very easy so I have also added manual checkpoints in this also

if using manual checkpoint option then we need to pass `setInputList(list, true); ` true to record value in history.
other wise it is ignored. if we don't use manual checkpoint then it will work as expected

